### PR TITLE
Update main.yml

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -30,5 +30,5 @@ include:
   - teams/sig_docs/team_meetings.yml
 #  - teams/sig_monitoring/onetimes.yml
   - teams/sig_monitoring/team_meetings.yml
-#  - teams/sig_standard_cert/onetimes.yml
+  - teams/sig_standard_cert/onetimes.yml
   - teams/sig_standard_cert/team_meetings.yml


### PR DESCRIPTION
make https://github.com/SovereignCloudStack/calendar/pull/280 visible in the main scs.ics calendar.

at least I currently can't see it at https://docs.scs.community/community/collaboration

and I also only have included the main.yml (scs.ics) in my local calendar application.